### PR TITLE
Add support for different Opera browsers

### DIFF
--- a/test.js
+++ b/test.js
@@ -44,11 +44,11 @@ test('windows parsing', async t => {
 		},
 		{
 			output: '\r\nHKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice\r\n    ProgId    REG_SZ    Opera GXStable\r\n\r\n',
-			expected: 'com.operasoftware.operagx',
+			expected: 'com.opera.gx',
 		},
 		{
 			output: '\r\nHKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice\r\n    ProgId    REG_SZ    OperaStable\r\n\r\n',
-			expected: 'com.operasoftware.opera',
+			expected: 'com.opera.Opera',
 		},
 		{
 			output: '\r\nHKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice\r\n    ProgId    REG_SZ    OperaNext\r\n\r\n',

--- a/test.js
+++ b/test.js
@@ -43,6 +43,22 @@ test('windows parsing', async t => {
 			expected: 'com.brave.Browser.beta',
 		},
 		{
+			output: '\r\nHKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice\r\n    ProgId    REG_SZ    Opera GXStable\r\n\r\n',
+			expected: 'com.operasoftware.operagx',
+		},
+		{
+			output: '\r\nHKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice\r\n    ProgId    REG_SZ    OperaStable\r\n\r\n',
+			expected: 'com.operasoftware.opera',
+		},
+		{
+			output: '\r\nHKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice\r\n    ProgId    REG_SZ    OperaNext\r\n\r\n',
+			expected: 'com.operasoftware.operanext',
+		},
+		{
+			output: '\r\nHKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice\r\n    ProgId    REG_SZ    OperaDeveloper\r\n\r\n',
+			expected: 'com.operasoftware.operadeveloper',
+		},
+		{
 			output: '\r\nHKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice\r\n    ProgId    REG_SZ    Potato\r\n\r\n',
 			expected: undefined,
 		},

--- a/windows.js
+++ b/windows.js
@@ -15,8 +15,8 @@ const windowsBrowserProgIds = {
 	BraveHTML: {name: 'Brave', id: 'com.brave.Browser'},
 	BraveBHTML: {name: 'Brave Beta', id: 'com.brave.Browser.beta'},
 	BraveSSHTM: {name: 'Brave Nightly', id: 'com.brave.Browser.nightly'},
-	Opera: {name: 'Opera GX', id: 'com.operasoftware.operagx'},
-	OperaStable: {name: 'Opera', id: 'com.operasoftware.opera'},
+	'Opera GXStable': {name: 'Opera GX', id: 'com.opera.gx'},
+	OperaStable: {name: 'Opera', id: 'com.opera.Opera'},
 	OperaNext: {name: 'Opera Next', id: 'com.operasoftware.operanext'},
 	OperaDeveloper: {name: 'Opera Developer', id: 'com.operasoftware.operadeveloper'},
 };

--- a/windows.js
+++ b/windows.js
@@ -15,6 +15,10 @@ const windowsBrowserProgIds = {
 	BraveHTML: {name: 'Brave', id: 'com.brave.Browser'},
 	BraveBHTML: {name: 'Brave Beta', id: 'com.brave.Browser.beta'},
 	BraveSSHTM: {name: 'Brave Nightly', id: 'com.brave.Browser.nightly'},
+	Opera: {name: 'Opera GX', id: 'com.operasoftware.operagx'},
+	OperaStable: {name: 'Opera', id: 'com.operasoftware.opera'},
+	OperaNext: {name: 'Opera Next', id: 'com.operasoftware.operanext'},
+	OperaDeveloper: {name: 'Opera Developer', id: 'com.operasoftware.operadeveloper'},
 };
 
 export class UnknownBrowserError extends Error {}

--- a/windows.js
+++ b/windows.js
@@ -31,7 +31,7 @@ export default async function defaultBrowser(_execFileAsync = execFileAsync) {
 		'ProgId',
 	]);
 
-	const match = /ProgId\s*REG_SZ\s*(?<id>\S+)/.exec(stdout);
+	const match = /ProgId\s*REG_SZ\s*(?<id>[^\r\n]+)/.exec(stdout);
 	if (!match) {
 		throw new UnknownBrowserError(`Cannot find Windows browser in stdout: ${JSON.stringify(stdout)}`);
 	}


### PR DESCRIPTION
Added a different set of Opera browsers.

- Opera GX
- Opera
- Opera Next
- Opera Developer

ProgId of Opera GX is added as just "Opera" within windowsBrowserProgIds object due to the matching regex not supporting whitespaces, since the Windows ProgId is "Opera GXStable", therefore the matching returns just Opera. This just happens with Opera GX, other browsers don't have spaces.