### PR TITLE
Adding RegularExpression and support Firefox (see Issue #11)

### DIFF
--- a/windows.js
+++ b/windows.js
@@ -15,6 +15,8 @@ const windowsBrowserProgIds = {
 	BraveHTML: {name: 'Brave', id: 'com.brave.Browser'},
 	BraveBHTML: {name: 'Brave Beta', id: 'com.brave.Browser.beta'},
 	BraveSSHTM: {name: 'Brave Nightly', id: 'com.brave.Browser.nightly'},
+	OperaStable: {name: 'Opera', id: 'com.opera.browser'},
+	'FirefoxURL\-([A-Z0-9]+)': {name: 'Firefox', id: 'org.mozilla.firefox'},
 };
 
 export class UnknownBrowserError extends Error {}
@@ -33,8 +35,38 @@ export default async function defaultBrowser(_execFileAsync = execFileAsync) {
 	}
 
 	const {id} = match.groups;
+	let browser = windowsBrowserProgIds[id];
 
-	const browser = windowsBrowserProgIds[id];
+	/* Check via Regular-Expressions */
+	if(!browser) {
+		try {
+			Object.keys(windowsBrowserProgIds).forEach((key) => {
+				let expression = new RegExp(key);
+
+				if(expression.test(id)) {
+					let matches = id.match(expression);
+					let additional = [];
+					browser = windowsBrowserProgIds[key];
+
+					if(matches.length > 1) {
+						matches.forEach((match, index) => {
+							if(index === 0) {
+								return;
+							}
+
+							additional.push(match);
+						});
+
+						/* Add additional informations */
+						browser.additional = additional;
+					}
+				}
+			});
+		} catch (e) {
+			/* Do Noting on Errors */
+		}
+	}
+
 	if (!browser) {
 		throw new UnknownBrowserError(`Unknown browser ID: ${id}`);
 	}


### PR DESCRIPTION
If **RegularExpression** is be used,
the field `additional` will be appeared:

> [!NOTE]
> Firefox has on registry the **ProgId** `FirefoxURL-308046B0AF4A39CB` as sample:

```javascript
{
  name: 'Firefox',
  id: 'org.mozilla.firefox',
  additional: [ '308046B0AF4A39CB' ]
}
```

Supporting new browsers:
```javascript
const windowsBrowserProgIds = {
	AppXq0fevzme2pys62n3e0fbqa7peapykr8v: {name: 'Edge', id: 'com.microsoft.edge.old'},
	MSEdgeDHTML: {name: 'Edge', id: 'com.microsoft.edge'}, // On macOS, it's "com.microsoft.edgemac"
	MSEdgeHTM: {name: 'Edge', id: 'com.microsoft.edge'}, // Newer Edge/Win10 releases
	'IE.HTTP': {name: 'Internet Explorer', id: 'com.microsoft.ie'},
	FirefoxURL: {name: 'Firefox', id: 'org.mozilla.firefox'},
	ChromeHTML: {name: 'Chrome', id: 'com.google.chrome'},
	BraveHTML: {name: 'Brave', id: 'com.brave.Browser'},
	BraveBHTML: {name: 'Brave Beta', id: 'com.brave.Browser.beta'},
	BraveSSHTM: {name: 'Brave Nightly', id: 'com.brave.Browser.nightly'},
	OperaStable: {name: 'Opera', id: 'com.opera.browser'},
	'FirefoxURL\-([A-Z0-9]+)': {name: 'Firefox', id: 'org.mozilla.firefox'},
};

```